### PR TITLE
Exception handling for broken image

### DIFF
--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -641,14 +641,21 @@ void IPVideoGrabber::threadedFunction()
                                 ///////////////////////////////
 
                                 // get the back image (ci^1)
-                                if(image_a[ci^1].loadImage(buffer))
+                                try
                                 {
-                                    isBackBufferReady_a = true;
-                                    nFrames_a++; // incrase frame cout
+                                    if(image_a[ci^1].loadImage(buffer))
+                                    {
+                                        isBackBufferReady_a = true;
+                                        nFrames_a++; // incrase frame cout
+                                    }
+                                    else
+                                    {
+                                        ofLogError("IPVideoGrabber") << "ofImage could not load the curent buffer, continuing.";
+                                    }
                                 }
-                                else
+                                catch (const char * e)
                                 {
-                                    ofLogError("IPVideoGrabber") << "ofImage could not load the curent buffer, continuing.";
+                                    ofLogError("IPVideoGrabber") << "FreeImage could not decode the current buffer as JPEG, meybe it's broken.";
                                 }
                                 
                                 ///////////////////////////////


### PR DESCRIPTION
On recent installation, I saw strange crashes as below:

```
Thread 15 Crashed:
0   libunwind.dylib                   0x9b15ca8e libunwind::UnwindCursor<libunwind::LocalAddressSpace, libunwind::Registers_x86>::setInfoBasedOnIPRegister(bool) + 12
1   libunwind.dylib                   0x9b15b5b0 unw_init_local + 272
2   libunwind.dylib                   0x9b15b3b1 _Unwind_RaiseException + 61
3   libc++abi.dylib                   0x953ff4c8 __cxa_throw + 103
4   cc.openFrameworks.ofapp           0x00370123 jpeg_error_exit(jpeg_common_struct*) + 91
5   cc.openFrameworks.ofapp           0x003a9c23 read_markers + 492
6   cc.openFrameworks.ofapp           0x003a7f42 consume_markers + 55
7   cc.openFrameworks.ofapp           0x003a20c3 jpeg_finish_decompress + 134
8   cc.openFrameworks.ofapp           0x003721a4 Load(FreeImageIO*, void*, int, int, void*) + 3488
9   cc.openFrameworks.ofapp           0x00361fff FreeImage_LoadFromHandle + 175
10  cc.openFrameworks.ofapp           0x0035fe32 FreeImage_LoadFromMemory + 62
11  cc.openFrameworks.ofapp           0x006893bf ofLoadImage(ofPixels_<unsigned char>&, ofBuffer const&) + 191
12  cc.openFrameworks.ofapp           0x0068a807 ofImage_<unsigned char>::loadImage(ofBuffer const&) + 39
13  cc.openFrameworks.ofapp           0x000ab6d4 ofx::Video::IPVideoGrabber::threadedFunction() + 3988
14  cc.openFrameworks.ofapp           0x000ad034 non-virtual thunk to ofx::Video::IPVideoGrabber::threadedFunction() + 20
15  cc.openFrameworks.ofapp           0x0067c68e ofThread::run() + 398
16  cc.openFrameworks.ofapp           0x000d6233 Poco::ThreadImpl::runnableEntry(void*) + 121
17  libsystem_pthread.dylib           0x95368ecf _pthread_body + 138
18  libsystem_pthread.dylib           0x95368e45 _pthread_start + 162
19  libsystem_pthread.dylib           0x95366f0e thread_start + 34
```

This happened many times so I wrapped the block that contains ofImage::loadImage for catching the exception.
It's working fine through a day, and no same crashes happened.

FYI I used following camera (max 16 connections and FullHD streams):

- [Canon VB-H43](http://www.usa.canon.com/cusa/professional/products/network_video_solutions/ptz_network_cameras/vb_h43)
- [Canon VB-S31D](http://www.usa.canon.com/cusa/professional/products/network_video_solutions/ptz_dome_network_cameras/vb_s31d)

Thanks!