### PR TITLE
Auto reconnection fix, change meaning of isConnected()

### DIFF
--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -215,7 +215,7 @@ void IPVideoGrabber::update()
             waitForDisconnect();
         }
         
-        if (needsAutoReconnect)
+        if (needsAutoReconnect && !_isThreadRunning)
         {
             if (maxReconnects < 0 || getReconnectCount() < maxReconnects)
             {

--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -382,7 +382,7 @@ uint64_t IPVideoGrabber::getTimeTillNextAutoRetry() const
 
     auto now = ofGetSystemTimeMillis();
 
-    if (nextAutoRetry_a == 0 or now >= nextAutoRetry_a)
+    if (nextAutoRetry_a == 0 || now >= nextAutoRetry_a)
     {
         return 0;
     }

--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -299,6 +299,7 @@ void IPVideoGrabber::disconnect()
 
 void IPVideoGrabber::close()
 {
+    autoReconnect = false;
     disconnect();
 }
 

--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -301,7 +301,10 @@ void IPVideoGrabber::disconnect()
 
 void IPVideoGrabber::close()
 {
-    autoReconnect = false;
+    if(autoReconnect){
+        ofLogNotice("IPVideoGrabber::close")  << "auto reconnect: OFF";
+        autoReconnect = false;
+    }
     disconnect();
 }
 

--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -343,6 +343,11 @@ bool IPVideoGrabber::getAutoReconnect() const
     return autoReconnect;
 }
 
+void IPVideoGrabber::setAutoReconnect(bool b)
+{
+    autoReconnect = b;
+}
+
 
 int IPVideoGrabber::getReconnectCount() const
 {

--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -90,6 +90,8 @@ IPVideoGrabber::IPVideoGrabber():
 
 IPVideoGrabber::~IPVideoGrabber()
 {
+    autoReconnect = false; // for sure
+    
     // N.B. In most cases, IPVideoGrabber::exit() will be called before
     // the program ever makes it into this destructor.
     waitForDisconnect();

--- a/src/IPVideoGrabber.cpp
+++ b/src/IPVideoGrabber.cpp
@@ -213,7 +213,7 @@ void IPVideoGrabber::update()
             waitForDisconnect();
         }
         
-        if (getNeedsReconnect())
+        if (needsAutoReconnect)
         {
             if (maxReconnects < 0 || getReconnectCount() < maxReconnects)
             {
@@ -233,7 +233,7 @@ void IPVideoGrabber::update()
             {
                 if (!connectionFailure)
                 {
-                    ofLogError("IPVideoGrabber::update") << "["<< cName << "] Connection retries exceeded, connection connection failed.  Call ::reset() to try again.";
+                    ofLogError("IPVideoGrabber::update") << "["<< cName << "] Connection retries exceeded, connection failed.  Call ::reset() to try again.";
                     connectionFailure = true;
                 }
             }

--- a/src/IPVideoGrabber.h
+++ b/src/IPVideoGrabber.h
@@ -259,6 +259,7 @@ private:
     ofEventListener _exitListener;
 #endif
 
+    std::atomic<bool> _isThreadRunning;
     std::atomic<bool> _isConnected;
 
     std::string defaultBoundaryMarker_a;

--- a/src/IPVideoGrabber.h
+++ b/src/IPVideoGrabber.h
@@ -235,6 +235,7 @@ public:
     uint64_t getReconnectTimeout() const;
     bool getNeedsReconnect() const;
     bool getAutoReconnect() const;
+    void setAutoReconnect(bool b);
     int getReconnectCount() const;
     int getMaxReconnects() const;
     void setMaxReconnects(int num);


### PR DESCRIPTION
This PR includes:

1. Auto reconnection fix
2. change meaning of isConnected()

for "2.", current isConnected() has problem that first connection trial interval indicates "connected" while not really connection established (this makes flickering when auto reconnecting if relying on `isConnected()` outside of addon).  "2." fixes this problem.